### PR TITLE
[Fix] Align Top3 sorting policy

### DIFF
--- a/backend/src/main/java/com/noaats/backend/promo/PromoCalculator.java
+++ b/backend/src/main/java/com/noaats/backend/promo/PromoCalculator.java
@@ -33,7 +33,6 @@ public final class PromoCalculator {
 		combinations.sort(Comparator
 			.comparingLong(PromoCombination::finalAmount)
 			.thenComparing(Comparator.comparingLong(PromoCombination::totalDiscount).reversed())
-			.thenComparing(Comparator.comparingDouble(PromoCombination::discountRateByTotal).reversed())
 			.thenComparingInt(PromoCombination::orderIndex)
 		);
 
@@ -41,7 +40,7 @@ public final class PromoCalculator {
 		List<PromoCombinationResult> results = new ArrayList<>(limit);
 		for (int i = 0; i < limit; i++) {
 			PromoCombination combo = combinations.get(i);
-			String reason = i == 0 ? "결제액 최소" : (i == 1 ? "총할인액 우선" : "할인율 우선");
+			String reason = i == 0 ? "결제액 최소" : (i == 1 ? "총할인액 우선" : "입력 순서 유지");
 			results.add(new PromoCombinationResult(
 				combo.priceCoupon(),
 				combo.shippingCoupon(),

--- a/backend/src/test/java/com/noaats/backend/promo/PromoCalculatorTest.java
+++ b/backend/src/test/java/com/noaats/backend/promo/PromoCalculatorTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 class PromoCalculatorTest {
 
 	@Test
-	void recommends_top3_by_final_amount_discount_rate_and_reason() {
+	void recommends_top3_by_final_amount_discount_and_reason() {
 		long subtotal = 10_000L;
 		long shippingFee = 3_000L;
 		List<CartItem> items = List.of(new CartItem("Item", 10_000L, 1, "SHOES"));
@@ -46,7 +46,7 @@ class PromoCalculatorTest {
 
 		assertEquals("결제액 최소", first.reason());
 		assertEquals("총할인액 우선", second.reason());
-		assertEquals("할인율 우선", third.reason());
+		assertEquals("입력 순서 유지", third.reason());
 
 		assertEquals(0.45, first.discountRateBySubtotal(), 0.0001);
 		assertEquals(0.3461, first.discountRateByTotal(), 0.0001);

--- a/prompts/feat-top3-sort-policy.md
+++ b/prompts/feat-top3-sort-policy.md
@@ -1,0 +1,12 @@
+# Feature: Top3 sorting policy alignment
+
+## User request
+- Top3 정렬 기준을 정책(결제액 최소 → 총할인액 → 입력 순서 유지)에 맞게 수정
+
+## Assistant actions
+- Updated PromoCalculator sort order and reason label
+- Updated PromoCalculatorTest expectations
+- Ran `./gradlew test`
+
+## Notes
+- No other behavior changes


### PR DESCRIPTION
## Background and Purpose
Align Top3 sorting with policy: 결제액 최소 → 총할인액 큰 순 → 입력 순서 유지.

## What changed
- Removed discount-rate tie-breaker from Top3 sort
- Updated reason label to "입력 순서 유지"
- Updated PromoCalculatorTest

## How to test
```bash
cd backend
./gradlew test
```

## Risk / Rollback plan
- Low risk, logic alignment only
- Rollback: revert this PR
