### PR TITLE
[Fix] Allow empty coupon lists in promo request

### DIFF
--- a/backend/src/main/java/com/noaats/backend/dto/promo/PromoRequestDto.java
+++ b/backend/src/main/java/com/noaats/backend/dto/promo/PromoRequestDto.java
@@ -20,8 +20,8 @@ public record PromoRequestDto(
 	@PositiveOrZero long shippingFee,
 	@Schema(description = "Payment method", example = "CARD")
 	@NotNull PaymentMethod paymentMethod,
-	@ArraySchema(schema = @Schema(implementation = PriceCouponDto.class), minItems = 1)
-	@Valid @NotNull @NotEmpty List<PriceCouponDto> priceCoupons,
-	@ArraySchema(schema = @Schema(implementation = ShippingCouponDto.class), minItems = 1)
-	@Valid @NotNull @NotEmpty List<ShippingCouponDto> shippingCoupons
+	@ArraySchema(schema = @Schema(implementation = PriceCouponDto.class), minItems = 0)
+	@Valid @NotNull List<PriceCouponDto> priceCoupons,
+	@ArraySchema(schema = @Schema(implementation = ShippingCouponDto.class), minItems = 0)
+	@Valid @NotNull List<ShippingCouponDto> shippingCoupons
 ) {}

--- a/backend/src/test/java/com/noaats/backend/controller/PromoControllerTest.java
+++ b/backend/src/test/java/com/noaats/backend/controller/PromoControllerTest.java
@@ -65,4 +65,23 @@ class PromoControllerTest {
 		verify(historyService).saveHistory(Mockito.eq(1L), Mockito.any(), Mockito.any());
 		SecurityContextHolder.clearContext();
 	}
+
+	@Test
+	void allows_empty_coupon_lists() {
+		HistoryService historyService = Mockito.mock(HistoryService.class);
+		PromoController controller = new PromoController(new PromoService(), historyService);
+		PromoRequestDto request = new PromoRequestDto(
+			10_000L,
+			List.of(new CartItemDto("Item", 10_000L, 1, "SHOES")),
+			3_000L,
+			PaymentMethod.CARD,
+			List.of(),
+			List.of()
+		);
+
+		var response = controller.calculate(request);
+
+		assertEquals(true, response.success());
+		assertNotNull(response.data());
+	}
 }

--- a/backend/src/test/java/com/noaats/backend/dto/promo/PromoDtoMapperTest.java
+++ b/backend/src/test/java/com/noaats/backend/dto/promo/PromoDtoMapperTest.java
@@ -80,4 +80,22 @@ class PromoDtoMapperTest {
 		assertNull(response.top3().getFirst().priceCoupon());
 		assertNull(response.top3().getFirst().shippingCoupon());
 	}
+
+	@Test
+	void maps_request_with_empty_coupon_lists() {
+		PromoRequestDto request = new PromoRequestDto(
+			0L,
+			List.of(new CartItemDto("Item", 1_000L, 1, "FOOD")),
+			0L,
+			null,
+			List.of(),
+			List.of()
+		);
+
+		PromoDtoMapper.PromoRequest domain = PromoDtoMapper.toDomainRequest(request);
+
+		assertEquals(1_000L, domain.subtotal());
+		assertEquals(0, domain.priceCoupons().size());
+		assertEquals(0, domain.shippingCoupons().size());
+	}
 }

--- a/prompts/feat-allow-empty-coupons.md
+++ b/prompts/feat-allow-empty-coupons.md
@@ -1,0 +1,12 @@
+# Feature: Allow empty coupon lists
+
+## User request
+- 쿠폰 없이도 계산 가능하도록 요청 DTO 제약 완화
+
+## Assistant actions
+- Removed @NotEmpty from price/shipping coupon lists in PromoRequestDto
+- Updated tests to cover empty coupon lists
+- Ran `./gradlew test`
+
+## Notes
+- Behavior unchanged; only validation relaxed


### PR DESCRIPTION
## Background and Purpose
Allow promo calculation without coupons by relaxing request validation.

## What changed
- Removed @NotEmpty from price/shipping coupon lists
- Updated controller/mapper tests to accept empty lists
- Added prompts log

## How to test
```bash
cd backend
./gradlew test
```

## Risk / Rollback plan
- Low risk: validation only
- Rollback: revert this PR
